### PR TITLE
Fix Dockerfile validation issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.8.0-alpine as builder
+FROM node:22.8.0-alpine AS builder
 
 ARG GIT_COMMIT_HASH=unknown
 ENV ORD_PROVIDER_SERVER_VERSION_HASH=${GIT_COMMIT_HASH}


### PR DESCRIPTION
Fix issue:

```
The 'as' keyword should match the case of the 'from' keyword: Dockerfile#L1
FromAsCasing: 'as' and 'FROM' keywords' casing do not match More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
```