### PR TITLE
feat: overall improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- HTTP response headers now have a new entry: `x-provider-server-version`
+- HTTP response headers now have a new entry: `x-ord-provider-server-version`
 - New API endpoint `/api/v1/status`
 - Documentation for re-deployment on CF
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [0.8.2] - 2025-04-16
+
+### Added
+
+- HTTP response headers now have a new entry: `x-provider-server-version`
+- New API endpoint `/api/v1/status`
+- Documentation for re-deployment on CF
+
+### Changed
+
+- Validation order of parameters / arguments / directories & files
+- Resilient URL (trailing slashes) checks
+
 ## [0.8.1] - 2025-04-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -297,17 +297,17 @@ cf push
 
 </details>
 
-##### Re-deploy CF app
+##### Re-deploy a CF app
 
 ```bash
 
 # 1. Login to Cloud Foundry
 cf login -a <api-url> -o <org> -s <space>
 
-# 2. Push the updated app without starting it
+# 2. Push the updated app
 cf push <your-app-name> \
 --no-manifest \
---docker-image "ghcr.io/open-resource-discovery/provider-server:latest" \
+--docker-image "ghcr.io/open-resource-discovery/provider-server:<your-new-version>" \
 --docker-username <docker-username>
 ```
 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,20 @@ cf push
 
 </details>
 
+##### Re-deploy CF app
+
+```bash
+
+# 1. Login to Cloud Foundry
+cf login -a <api-url> -o <org> -s <space>
+
+# 2. Push the updated app without starting it
+cf push <your-app-name> \
+--no-manifest \
+--docker-image "ghcr.io/open-resource-discovery/provider-server:latest" \
+--docker-username <docker-username>
+```
+
 ## GitHub Token Permissions
 
 When using the GitHub source type (`-s github`), you need to provide a GitHub token with appropriate permissions. Both fine-grained personal access tokens (PATs) and classic tokens are supported.

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,4 +34,7 @@ export default {
   testMatch: ["<rootDir>/src/**/*.test.ts"],
   testTimeout: 30000,
   watchPlugins: ["jest-watch-typeahead/filename", "jest-watch-typeahead/testname"],
+  testEnvironmentOptions: {
+    NODE_OPTIONS: "--experimental-vm-modules",
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "0.8.2-dev1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/provider-server",
-      "version": "0.8.2-dev1",
+      "version": "0.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/auth": "^5.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "0.8.2-dev",
+  "version": "0.8.2-dev1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/provider-server",
-      "version": "0.8.2-dev",
+      "version": "0.8.2-dev1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/auth": "^5.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "0.8.1",
+  "version": "0.8.2-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/provider-server",
-      "version": "0.8.1",
+      "version": "0.8.2-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/auth": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "0.8.1",
+  "version": "0.8.2-dev",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=22.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "0.8.2-dev1",
+  "version": "0.8.2",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=22.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "0.8.2-dev",
+  "version": "0.8.2-dev1",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=22.8.0",

--- a/src/__tests__/server.integration.test.ts
+++ b/src/__tests__/server.integration.test.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { PATH_CONSTANTS } from "src/constant.js";
 import { OptAuthMethod, OptSourceType } from "src/model/cli.js";
 import { ProviderServerOptions, startProviderServer } from "src/server.js";
+import { getPackageVersion } from "../routes/versionRouter.js";
 
 // Mock bcrypt to avoid native module issues in tests
 jest.mock("bcryptjs", () => ({
@@ -275,6 +276,18 @@ describe("Server Integration", () => {
       });
 
       expect(response.headers.get("etag")).toBeTruthy();
+    });
+  });
+
+  describe("Version Endpoint", () => {
+    it("should return the correct version and status", async () => {
+      const packageVersion = getPackageVersion();
+      const response = await fetch(`${SERVER_URL}/version`);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("sap-provider-server-version")).toBe(packageVersion);
+      const data = await response.json();
+      expect(data).toEqual({ version: packageVersion });
     });
   });
 });

--- a/src/__tests__/server.integration.test.ts
+++ b/src/__tests__/server.integration.test.ts
@@ -285,7 +285,7 @@ describe("Server Integration", () => {
       const response = await fetch(`${SERVER_URL}/api/v1/status`);
 
       expect(response.status).toBe(200);
-      expect(response.headers.get("x-provider-server-version")).toBe(packageVersion);
+      expect(response.headers.get("x-ord-provider-server-version")).toBe(packageVersion);
       const data = await response.json();
       expect(data).toEqual({ version: packageVersion });
     });

--- a/src/__tests__/server.integration.test.ts
+++ b/src/__tests__/server.integration.test.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { PATH_CONSTANTS } from "src/constant.js";
 import { OptAuthMethod, OptSourceType } from "src/model/cli.js";
 import { ProviderServerOptions, startProviderServer } from "src/server.js";
-import { getPackageVersion } from "../routes/versionRouter.js";
+import { getPackageVersion } from "../routes/statusRouter.js";
 
 // Mock bcrypt to avoid native module issues in tests
 jest.mock("bcryptjs", () => ({
@@ -279,13 +279,13 @@ describe("Server Integration", () => {
     });
   });
 
-  describe("Version Endpoint", () => {
-    it("should return the correct version and status", async () => {
+  describe("Status Endpoint", () => {
+    it("should return the correct status object with version", async () => {
       const packageVersion = getPackageVersion();
-      const response = await fetch(`${SERVER_URL}/version`);
+      const response = await fetch(`${SERVER_URL}/api/v1/status`);
 
       expect(response.status).toBe(200);
-      expect(response.headers.get("sap-provider-server-version")).toBe(packageVersion);
+      expect(response.headers.get("x-provider-server-version")).toBe(packageVersion);
       const data = await response.json();
       expect(data).toEqual({ version: packageVersion });
     });

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -8,7 +8,7 @@ export const PATH_CONSTANTS = {
   ORD_URL_PATH: "ord",
   ORD_VERSION: "v1",
   WELL_KNOWN_ENDPOINT: "/.well-known/open-resource-discovery",
-  VERSION_ENDPOINT: "/version",
+  STATUS_ENDPOINT: "/api/v1/status",
 
   // Derived paths
   SERVER_PREFIX: `/ord/v1`,

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,3 +1,7 @@
+import { config } from "dotenv";
+
+config();
+
 // URL path constants
 export const PATH_CONSTANTS = {
   // Base paths

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -4,6 +4,7 @@ export const PATH_CONSTANTS = {
   ORD_URL_PATH: "ord",
   ORD_VERSION: "v1",
   WELL_KNOWN_ENDPOINT: "/.well-known/open-resource-discovery",
+  VERSION_ENDPOINT: "/version",
 
   // Derived paths
   SERVER_PREFIX: `/ord/v1`,

--- a/src/middleware/authenticationSetup.ts
+++ b/src/middleware/authenticationSetup.ts
@@ -33,7 +33,10 @@ export async function setupAuthentication(server: FastifyInstanceType, options: 
     server.addHook(
       "onRequest",
       function (request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction): void {
-        if (request.url.startsWith(PATH_CONSTANTS.WELL_KNOWN_ENDPOINT)) {
+        if (
+          request.url.startsWith(PATH_CONSTANTS.WELL_KNOWN_ENDPOINT) ||
+          request.url.startsWith(PATH_CONSTANTS.VERSION_ENDPOINT)
+        ) {
           done();
         } else {
           // @ts-expect-error request type matching

--- a/src/middleware/authenticationSetup.ts
+++ b/src/middleware/authenticationSetup.ts
@@ -35,7 +35,7 @@ export async function setupAuthentication(server: FastifyInstanceType, options: 
       function (request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction): void {
         if (
           request.url.startsWith(PATH_CONSTANTS.WELL_KNOWN_ENDPOINT) ||
-          request.url.startsWith(PATH_CONSTANTS.VERSION_ENDPOINT)
+          request.url.startsWith(PATH_CONSTANTS.STATUS_ENDPOINT)
         ) {
           done();
         } else {

--- a/src/model/cli.ts
+++ b/src/model/cli.ts
@@ -39,7 +39,7 @@ export function parseAuthMethods(value: string): OptAuthMethod[] {
 export interface CommandLineOptions {
   sourceType: OptSourceType;
   directory?: string;
-  documentsSubdirectory?: string;
+  documentsSubdirectory: string;
   auth: OptAuthMethod[];
   baseUrl?: string;
   host?: string;

--- a/src/model/server.ts
+++ b/src/model/server.ts
@@ -3,6 +3,7 @@ import { CommandLineOptions, OptAuthMethod, OptSourceType } from "src/model/cli.
 import { getBaseUrl as updateBaseUrl } from "src/util/ordConfig.js";
 import { normalizePath } from "src/util/pathUtils.js";
 import { config } from "dotenv";
+
 config();
 
 export interface ProviderServerOptions {
@@ -42,14 +43,16 @@ function parseOrdDirectory(ordDirectory: string | undefined, sourceType: OptSour
 
 export function buildProviderServerOptions(options: CommandLineOptions): ProviderServerOptions {
   log.info("Building server configuration...");
+  const documentsSubDirectory = options.documentsSubdirectory.replace(/^\//, "").replace(/\/$/, "");
+
   return {
     ordDirectory: parseOrdDirectory(options.directory, options.sourceType),
-    ordDocumentsSubDirectory: options.documentsSubdirectory || "documents",
+    ordDocumentsSubDirectory: documentsSubDirectory,
     baseUrl: updateBaseUrl(options.baseUrl),
-    host: options.host,
+    host: options.host?.replace(/\/$/, ""),
     port: options.port ? parseInt(options.port) : undefined,
     sourceType: options.sourceType,
-    githubApiUrl: options.githubApiUrl || process.env.GITHUB_API_URL,
+    githubApiUrl: (options.githubApiUrl || process.env.GITHUB_API_URL)?.replace(/\/$/, ""),
     githubRepository: options.githubRepository || process.env.GITHUB_REPOSITORY,
     githubBranch: options.githubBranch || process.env.GITHUB_BRANCH,
     githubToken: options.githubToken || process.env.GITHUB_TOKEN,

--- a/src/routes/statusRouter.ts
+++ b/src/routes/statusRouter.ts
@@ -18,13 +18,13 @@ export function getPackageVersion(): string {
 
 const version = getPackageVersion();
 
-function versionRouter(fastify: FastifyInstance, _opts: FastifyPluginOptions, done: (err?: Error) => void): void {
-  fastify.get("/version", (_request: FastifyRequest, _reply: FastifyReply) => {
+function statusRouter(fastify: FastifyInstance, _opts: FastifyPluginOptions, done: (err?: Error) => void): void {
+  fastify.get("/api/v1/status", (_request: FastifyRequest, _reply: FastifyReply) => {
     return { version };
   });
   done();
 }
 
-export default fp(versionRouter, {
-  name: "version-router",
+export default fp(statusRouter, {
+  name: "status-router",
 });

--- a/src/routes/versionRouter.ts
+++ b/src/routes/versionRouter.ts
@@ -1,0 +1,30 @@
+import { FastifyInstance, FastifyPluginOptions, FastifyReply, FastifyRequest } from "fastify";
+import fp from "fastify-plugin";
+import fs from "node:fs";
+import path from "node:path";
+import { log } from "../util/logger.js";
+
+export function getPackageVersion(): string {
+  try {
+    const packageJsonPath = path.resolve(process.cwd(), "package.json");
+    const packageJsonContent = fs.readFileSync(packageJsonPath, "utf-8");
+    const packageJson = JSON.parse(packageJsonContent);
+    return packageJson.version || "unknown";
+  } catch (error) {
+    log.error("Failed to read package.json version:", error);
+    return "unknown";
+  }
+}
+
+const version = getPackageVersion();
+
+function versionRouter(fastify: FastifyInstance, _opts: FastifyPluginOptions, done: (err?: Error) => void): void {
+  fastify.get("/version", (_request: FastifyRequest, _reply: FastifyReply) => {
+    return { version };
+  });
+  done();
+}
+
+export default fp(versionRouter, {
+  name: "version-router",
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,7 +67,7 @@ async function setupServer(server: FastifyInstanceType): Promise<void> {
 
   // Add version header to all responses
   server.addHook("onSend", (_request, reply, _, done) => {
-    reply.header("x-provider-server-version", version);
+    reply.header("x-ord-provider-server-version", version);
     done();
   });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,8 @@
 import fastifyETag from "@fastify/etag";
 import fastify from "fastify";
+import fs from "node:fs";
+import path from "node:path";
+import versionRouter from "./routes/versionRouter.js";
 import { PATH_CONSTANTS } from "src/constant.js";
 import { setupAuthentication } from "src/middleware/authenticationSetup.js";
 import { errorHandler } from "src/middleware/errorHandler.js";
@@ -9,6 +12,21 @@ import { type ProviderServerOptions } from "src/model/server.js";
 import { log } from "src/util/logger.js";
 import { RouterFactory } from "./factories/routerFactory.js";
 import { FqnDocumentMap } from "./util/fqnHelpers.js";
+
+// Helper to get package.json version
+function getPackageVersion(): string {
+  try {
+    const packageJsonPath = path.resolve(process.cwd(), "package.json");
+    const packageJsonContent = fs.readFileSync(packageJsonPath, "utf-8");
+    const packageJson = JSON.parse(packageJsonContent);
+    return packageJson.version || "unknown";
+  } catch (error) {
+    log.error("Failed to read package.json version:", error);
+    return "unknown";
+  }
+}
+
+const version = getPackageVersion();
 
 export { ProviderServerOptions }; // Re-export the type
 
@@ -43,6 +61,15 @@ export async function startProviderServer(opts: ProviderServerOptions): Promise<
 async function setupServer(server: FastifyInstanceType): Promise<void> {
   server.setErrorHandler(errorHandler);
   await server.register(fastifyETag);
+
+  // Register version router
+  await server.register(versionRouter);
+
+  // Add version header to all responses
+  server.addHook("onSend", (_request, reply, _, done) => {
+    reply.header("sap-provider-server-version", version);
+    done();
+  });
 }
 
 async function setupRouting(server: FastifyInstanceType, opts: ProviderServerOptions): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import fastifyETag from "@fastify/etag";
 import fastify from "fastify";
 import fs from "node:fs";
 import path from "node:path";
-import versionRouter from "./routes/versionRouter.js";
+import statusRouter from "./routes/statusRouter.js";
 import { PATH_CONSTANTS } from "src/constant.js";
 import { setupAuthentication } from "src/middleware/authenticationSetup.js";
 import { errorHandler } from "src/middleware/errorHandler.js";
@@ -62,12 +62,12 @@ async function setupServer(server: FastifyInstanceType): Promise<void> {
   server.setErrorHandler(errorHandler);
   await server.register(fastifyETag);
 
-  // Register version router
-  await server.register(versionRouter);
+  // Register status router
+  await server.register(statusRouter);
 
   // Add version header to all responses
   server.addHook("onSend", (_request, reply, _, done) => {
-    reply.header("sap-provider-server-version", version);
+    reply.header("x-provider-server-version", version);
     done();
   });
 }

--- a/src/util/optsValidation.ts
+++ b/src/util/optsValidation.ts
@@ -13,6 +13,7 @@ import { fetchGitHubFile, getGithubDirectoryContents } from "./github.js";
 import { log } from "./logger.js";
 import { validateOrdDocument } from "./validateOrdDocument.js";
 import { isBcryptHash } from "./passwordHash.js";
+import { getBaseUrl } from "./ordConfig.js";
 
 // @ts-expect-error baseUrl pattern selection
 export const ordBaseUrlPattern = new RegExp(ordConfigurationSchema.properties["baseUrl"]["pattern"]);
@@ -54,7 +55,9 @@ function validateBaseUrlOption(options: CommandLineOptions, errors: string[]): v
     return;
   }
 
-  if (!ordBaseUrlPattern.test(options.baseUrl)) {
+  const baseUrlFixed = getBaseUrl(options.baseUrl);
+
+  if (!ordBaseUrlPattern.test(baseUrlFixed)) {
     errors.push(`Detected invalid baseUrl: ${options.baseUrl}`);
   }
 }


### PR DESCRIPTION
- Validation is now splitted into "offline" and remote checks ( fail early )
- New `/api/v1/status` endpoint is added
- Each http-response has now a version header (`x-ord-provider-server-version`)
- Extra slashes in args/vars (e.g for `GITHUB_API_URL`) are now checked and removed
- CLI help is not showing up, when in `production` mode