### PR TITLE
fix: ord id lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "0.8.2",
+  "version": "0.8.3-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/provider-server",
-      "version": "0.8.2",
+      "version": "0.8.3-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/auth": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "0.8.2",
+  "version": "0.8.3-dev",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=22.8.0",

--- a/src/routes/documentRouter.ts
+++ b/src/routes/documentRouter.ts
@@ -4,7 +4,7 @@ import { PATH_CONSTANTS } from "../constant.js";
 import { log } from "../util/logger.js";
 import { BaseRouter } from "./baseRouter.js";
 import { FqnDocumentMap, isOrdId } from "../util/fqnHelpers.js";
-import { joinFilePaths } from "../util/pathUtils.js";
+import { joinFilePaths, ordIdToPathSegment } from "../util/pathUtils.js";
 import { OptAuthMethod } from "../model/cli.js";
 import { BackendError } from "../model/error/BackendError.js";
 import { InternalServerError } from "../model/error/InternalServerError.js";
@@ -121,7 +121,11 @@ export class DocumentRouter extends BaseRouter {
       if (resourceMap) {
         relativePath = resourceMap.filePath;
       } else {
-        relativePath = joinFilePaths(ordId, unknownPath);
+        if (isOrdId(ordId)) {
+          relativePath = joinFilePaths(ordIdToPathSegment(ordId), unknownPath);
+        } else {
+          relativePath = joinFilePaths(ordId, unknownPath);
+        }
       }
 
       try {


### PR DESCRIPTION
If an entry in the resourceMap is missing, we should first replace colons with underscores, before trying to fetch it.