### PR TITLE
chore: Renovate update for Nodejs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "docker:enableMajor", ":pinAllExceptPeerDependencies"],
   "semanticCommits": "enabled",
-  "enabledManagers": ["npm", "dockerfile"],
+  "enabledManagers": ["npm", "dockerfile", "github-actions"],
   "branchPrefix": "deps/",
   "timezone": "Europe/Berlin",
   "schedule": ["every weekend"],
@@ -10,9 +10,18 @@
   "prConcurrentLimit": 0,
   "packageRules": [
     {
+      "groupName": "Node.js",
+      "matchManagers": ["dockerfile", "github-actions"],
+      "matchPackageNames": ["node"],
+      "matchUpdateTypes": ["major", "minor", "patch", "digest"],
+      "semanticCommitType": "chore",
+      "automerge": true
+    },
+    {
       "groupName": "Docker Dependencies",
       "matchManagers": ["dockerfile"],
       "matchDatasources": ["docker"],
+      "excludePackageNames": ["node"],
       "matchUpdateTypes": ["major", "minor", "patch", "digest"],
       "semanticCommitType": "chore",
       "automerge": true

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "docker:enableMajor", ":pinAllExceptPeerDependencies"],
+  "extends": [
+    "config:recommended",
+    "docker:enableMajor",
+    ":pinAllExceptPeerDependencies",
+    "helpers:pinGitHubActionDigests"
+  ],
   "semanticCommits": "enabled",
   "enabledManagers": ["npm", "dockerfile", "github-actions"],
   "branchPrefix": "deps/",


### PR DESCRIPTION
- Improve renovate setting for synchronous (GHA + Dockerfile) Nodejs updates
- Ignore Nodejs in Dockerfile standalone update

#186 