### PR TITLE
fix: resource name replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Fixed
+
+- Fix ORD ID path segment conversion to preserve underscores in the resource name segment
+
 ## [[1.1.0](https://github.com/open-resource-discovery/provider-server/releases/tag/v1.1.0)] - 2026-04-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.1.1",
+  "version": "1.1.1-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/provider-server",
-      "version": "1.1.1",
+      "version": "1.1.1-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/auth": "5.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/provider-server",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/auth": "5.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.1.1-dev.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/provider-server",
-      "version": "1.1.1-dev.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/auth": "5.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.1.1",
+  "version": "1.1.1-dev.0",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=24.10.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=24.10.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.1.1-dev.0",
+  "version": "1.1.1",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=24.10.7",

--- a/src/util/__tests__/pathUtils.test.ts
+++ b/src/util/__tests__/pathUtils.test.ts
@@ -87,6 +87,16 @@ describe("Path Utilities", () => {
       );
     });
 
+    it("should preserve two underscores in resource name", () => {
+      expect(pathSegmentToOrdId("sap.xref_apiResource_material_create_confirm_v1")).toBe(
+        "sap.xref:apiResource:material_create_confirm:v1",
+      );
+    });
+
+    it("should preserve three underscores in resource name", () => {
+      expect(pathSegmentToOrdId("sap.xref_apiResource_a_b_c_d_v2")).toBe("sap.xref:apiResource:a_b_c_d:v2");
+    });
+
     it("should preserve underscores in resource name for eventResource", () => {
       expect(pathSegmentToOrdId("sap.xref_eventResource_supplier_management_v2")).toBe(
         "sap.xref:eventResource:supplier_management:v2",
@@ -109,6 +119,8 @@ describe("Path Utilities", () => {
       const ordIds = [
         "sap.xref:apiResource:astronomy:v1",
         "sap.xref:apiResource:catalog_provider:v1",
+        "sap.xref:apiResource:material_create_confirm:v1",
+        "sap.xref:apiResource:a_b_c_d:v2",
         "sap.xref:package:_my-reference-app:v1",
         "sap.xref:eventResource:supplier_management:v2",
         "sap.xref:apiResource:DocumentCreateConfirmation_Async:v1",

--- a/src/util/__tests__/pathUtils.test.ts
+++ b/src/util/__tests__/pathUtils.test.ts
@@ -65,18 +65,57 @@ describe("Path Utilities", () => {
       expect(ordIdToPathSegment("sap.xref:apiResource:astronomy:v1")).toBe("sap.xref_apiResource_astronomy_v1");
     });
 
+    it("should preserve underscores in resource name", () => {
+      expect(ordIdToPathSegment("sap.xref:apiResource:catalog_provider:v1")).toBe(
+        "sap.xref_apiResource_catalog_provider_v1",
+      );
+    });
+
     it("should not modify strings without colons", () => {
       expect(ordIdToPathSegment("resource")).toBe("resource");
     });
   });
 
   describe("pathSegmentToOrdId", () => {
-    it("should replace underscores with colons", () => {
+    it("should convert simple path segment to ORD ID", () => {
       expect(pathSegmentToOrdId("sap.xref_apiResource_astronomy_v1")).toBe("sap.xref:apiResource:astronomy:v1");
+    });
+
+    it("should preserve underscores in resource name for apiResource", () => {
+      expect(pathSegmentToOrdId("sap.xref_apiResource_catalog_provider_v1")).toBe(
+        "sap.xref:apiResource:catalog_provider:v1",
+      );
+    });
+
+    it("should preserve underscores in resource name for eventResource", () => {
+      expect(pathSegmentToOrdId("sap.xref_eventResource_supplier_management_v2")).toBe(
+        "sap.xref:eventResource:supplier_management:v2",
+      );
+    });
+
+    it("should preserve leading underscore in resource name", () => {
+      expect(pathSegmentToOrdId("sap.xref_package__my-reference-app_v1")).toBe("sap.xref:package:_my-reference-app:v1");
+    });
+
+    it("should handle package resource type", () => {
+      expect(pathSegmentToOrdId("sap.xref_package_my-reference-app_v1")).toBe("sap.xref:package:my-reference-app:v1");
     });
 
     it("should not modify strings without underscores", () => {
       expect(pathSegmentToOrdId("resource")).toBe("resource");
+    });
+
+    it("should roundtrip ORD IDs with underscores in resource name", () => {
+      const ordIds = [
+        "sap.xref:apiResource:astronomy:v1",
+        "sap.xref:apiResource:catalog_provider:v1",
+        "sap.xref:package:_my-reference-app:v1",
+        "sap.xref:eventResource:supplier_management:v2",
+        "sap.xref:apiResource:DocumentCreateConfirmation_Async:v1",
+      ];
+      for (const ordId of ordIds) {
+        expect(pathSegmentToOrdId(ordIdToPathSegment(ordId))).toBe(ordId);
+      }
     });
   });
 

--- a/src/util/pathUtils.ts
+++ b/src/util/pathUtils.ts
@@ -43,12 +43,25 @@ export function ordIdToPathSegment(ordId: string): string {
 }
 
 /**
- * Converts a filesystem path segment back to an ORD ID
+ * Converts a filesystem path segment back to an ORD ID.
+ *
+ * ORD IDs have 4 colon-separated segments: namespace:resourceType:resourceName:version.
+ * Only resourceName (segment 3) can contain underscores. Since namespace, resourceType,
+ * and version never contain underscores, we split by _ and rejoin the middle parts.
+ *
  * @param pathSegment The path segment to convert
  * @returns Original ORD ID
  */
 export function pathSegmentToOrdId(pathSegment: string): string {
-  return pathSegment.replace(/_/g, ":");
+  const parts = pathSegment.split("_");
+  if (parts.length < 4) return pathSegment.replace(/_/g, ":");
+
+  const namespace = parts[0];
+  const resourceType = parts[1];
+  const version = parts[parts.length - 1];
+  const resourceName = parts.slice(2, -1).join("_");
+
+  return `${namespace}:${resourceType}:${resourceName}:${version}`;
 }
 
 /**


### PR DESCRIPTION
Fix ORD ID path segment conversion to preserve underscores in the resource name segment