### PR TITLE
feat: Add `x-github-current-commit-hash` response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Add `x-github-current-commit-hash` response header when serving from GitHub source type
+
 ## [[1.1.1](https://github.com/open-resource-discovery/provider-server/releases/tag/v1.1.1)] - 2026-04-22
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.1.1",
+  "version": "1.1.2-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/provider-server",
-      "version": "1.1.1",
+      "version": "1.1.2-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/auth": "5.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.1.2-dev.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/provider-server",
-      "version": "1.1.2-dev.0",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/auth": "5.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.1.2-dev.0",
+  "version": "1.1.2",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=24.10.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.1.1",
+  "version": "1.1.2-dev.0",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=24.10.7",

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,7 @@ let fileSystemManager: FileSystemManager | null = null;
 let updateScheduler: UpdateScheduler | null = null;
 let updateStateManager: UpdateStateManager | null = null;
 let cacheServiceGlobal: CacheService | null = null;
+let currentCommitHash: string | null = null;
 
 export async function startProviderServer(opts: ProviderServerOptions): Promise<ShutdownFunction> {
   log.info("============================================================");
@@ -91,6 +92,12 @@ export async function startProviderServer(opts: ProviderServerOptions): Promise<
 
     // Initialize the scheduler to load metadata
     await updateScheduler.initialize();
+
+    // Update cached commit hash when git content is updated
+    updateScheduler.on("update-completed", async () => {
+      const metadata = await fileSystemManager!.getMetadata();
+      currentCommitHash = metadata?.commitHash || null;
+    });
   }
 
   // Basic server setup
@@ -157,6 +164,10 @@ async function performOnlineValidation(
 
     if (validationResult.contentAvailable) {
       log.info("Online validation complete. Content is now available.");
+
+      // Cache the commit hash for the response header
+      const metadata = await fileSystemManager.getMetadata();
+      currentCommitHash = metadata?.commitHash || null;
 
       // Notify the repository that content is now available by recreating it
       // This will update the directoryExists flag
@@ -252,6 +263,9 @@ async function setupServer(server: FastifyInstanceType, opts: ProviderServerOpti
   // Add version header to all responses
   server.addHook("onSend", (_request, reply, _, done) => {
     reply.header("x-ord-provider-server-version", version);
+    if (currentCommitHash) {
+      reply.header("x-github-current-commit-hash", currentCommitHash);
+    }
     done();
   });
 }


### PR DESCRIPTION
Introduce a new response header to include the current commit hash when serving from GitHub source type. 