### PR TITLE
Feature/absolute urls, 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ npx @open-resource-discovery/provider-server --help
 | Option                                 | Default                  | Required         | Env Var                      | Description                                                                                                                                           |
 | -------------------------------------- | ------------------------ | ---------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-b, --base-url <type>`                | `local`                  | Yes              | `ORD_BASE_URL`               | Base URL of the server. If deployed in CF environment, the VCAP_APPLICATION env will be used as fallback                                              |
+| `--absolute-urls`                      | `false`                  | No               | `ORD_ABSOLUTE_URLS`          | Emit fully-qualified absolute URLs (prefixed with `--base-url`) in all ORD responses instead of root-relative `/ord/v1/...` paths                     |
 | `-s, --source-type <type>`             | `local`                  | No               | `ORD_SOURCE_TYPE`            | Source type for ORD Documents (`local` or `github`)                                                                                                   |
 | `-a, --auth <types>`                   | `open`                   | No               | `ORD_AUTH_TYPE`              | Server authentication method(s) (`open`, `basic`, `cf-mtls`)                                                                                          |
 | `-d, --directory <path>`               | -                        | Yes (for local)  | `ORD_DIRECTORY`              | Root directory containing the ORD Documents directory and resource definition files.                                                                  |
@@ -235,6 +236,13 @@ This structure applies to both source types:
    - This `baseUrl` value will:
      - Be set in the ORD Configuration
      - Override the existing baseUrl in the `describedSystemInstance` field of any ORD Documents
+
+4. **Absolute URLs (`--absolute-urls` / `ORD_ABSOLUTE_URLS=true`)**
+   - By default the server emits **root-relative** paths in all ORD responses (e.g. `/ord/v1/documents/my-doc`).
+   - When `--absolute-urls` is set, every URL the server emits is prefixed with `--base-url`, producing fully-qualified URLs (e.g. `https://my-server.example.com/ord/v1/documents/my-doc`).
+   - This affects: document URLs in the ORD Configuration, resource definition URLs, and package link/file URLs.
+   - URLs that are already absolute (`http://` / `https://`) in the source documents are never modified.
+   - Use this option when deploying behind a gateway or when ORD consumers must resolve all links without knowing the server's base URL out-of-band.
 
 ### Perspective Filtering
 

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -86,3 +86,76 @@ describe("End-to-End Testing", () => {
     expect(resourceResponse.status).toBe(200);
   });
 });
+
+describe("End-to-End Testing with absolute URLs", () => {
+  const TEST_PORT = 8087;
+  const TEST_HOST = "127.0.0.1";
+  const SERVER_URL = `http://${TEST_HOST}:${TEST_PORT}`;
+  const BASIC_AUTH_PASSWORD = "$2b$10$hashedPassword";
+
+  let shutdownServer: () => Promise<void>;
+
+  beforeAll(async () => {
+    shutdownServer = await startProviderServer({
+      ordDirectory: path.join(process.cwd(), "src/__tests__/test-files"),
+      ordDocumentsSubDirectory: PATH_CONSTANTS.DOCUMENTS_SUBDIRECTORY,
+      sourceType: OptSourceType.Local,
+      baseUrl: SERVER_URL,
+      absoluteUrls: true,
+      host: "0.0.0.0",
+      port: TEST_PORT,
+      authentication: {
+        methods: [OptAuthMethod.Basic],
+        basicAuthUsers: { admin: BASIC_AUTH_PASSWORD },
+      },
+      dataDir: "./test-data-absolute",
+      updateDelay: 30000,
+      statusDashboardEnabled: false,
+      cors: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await shutdownServer();
+    try {
+      await fs.rm("./test-data-absolute", { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should emit absolute URLs in ORD configuration", async () => {
+    const configResponse = await fetch(`${SERVER_URL}${PATH_CONSTANTS.WELL_KNOWN_ENDPOINT}`);
+    expect(configResponse.status).toBe(200);
+    const config = (await configResponse.json()) as OrdConfiguration;
+
+    const documents = config.openResourceDiscoveryV1.documents;
+    expect(documents).not.toHaveLength(0);
+
+    // All document URLs must be absolute
+    for (const doc of documents!) {
+      expect(doc.url).toMatch(/^https?:\/\//);
+      expect(doc.url).toContain(SERVER_URL);
+    }
+  });
+
+  it("should emit absolute resource definition URLs in ORD documents", async () => {
+    const configResponse = await fetch(`${SERVER_URL}${PATH_CONSTANTS.WELL_KNOWN_ENDPOINT}`);
+    const config = (await configResponse.json()) as OrdConfiguration;
+    const credentials = Buffer.from("admin:secret").toString("base64");
+
+    const documentUrl = config.openResourceDiscoveryV1.documents![0].url;
+    // documentUrl is absolute — fetch it directly
+    const documentResponse = await fetch(documentUrl, {
+      headers: { Authorization: `Basic ${credentials}` },
+    });
+    expect(documentResponse.status).toBe(200);
+    const document = (await documentResponse.json()) as OrdDocument;
+
+    // API resource definition URLs must also be absolute
+    const resourceDefs = document.apiResources?.[0]?.resourceDefinitions;
+    if (resourceDefs && resourceDefs.length > 0) {
+      expect(resourceDefs[0].url).toMatch(/^https?:\/\//);
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,11 @@ program
     parseAuthMethods,
     process.env.ORD_AUTH_TYPE ? parseAuthMethods(process.env.ORD_AUTH_TYPE) : [OptAuthMethod.Open],
   )
+  .option(
+    "--absolute-urls",
+    "Emit absolute URLs (including baseUrl) in all ORD responses instead of root-relative paths",
+    process.env.ORD_ABSOLUTE_URLS === "true",
+  )
   .option("--host <host>", "Host for server, without port", process.env.SERVER_HOST || "0.0.0.0")
   .option("--port <port number>", "Server port", process.env.SERVER_PORT || "8080")
   .option("--github-api-url <githubApiUrl>", "GitHub host to make API calls", process.env.GITHUB_API_URL)

--- a/src/factories/routerFactory.ts
+++ b/src/factories/routerFactory.ts
@@ -14,6 +14,7 @@ import { log } from "../util/logger.js";
 interface FactoryOptions {
   sourceType: OptSourceType;
   baseUrl: string;
+  absoluteUrls?: boolean;
   authMethods: OptAuthMethod[];
   fqnDocumentMap: FqnDocumentMap;
   documentsSubDirectory?: string;
@@ -40,6 +41,7 @@ export class RouterFactory {
       repository = new LocalDocumentRepository(currentPath);
       processingContext = {
         baseUrl: options.baseUrl,
+        absoluteUrls: options.absoluteUrls,
         authMethods: options.authMethods,
         githubBranch: options.githubOpts.githubBranch,
         githubApiUrl: options.githubOpts.githubApiUrl,
@@ -50,6 +52,7 @@ export class RouterFactory {
       repository = new LocalDocumentRepository(options.ordDirectory);
       processingContext = {
         baseUrl: options.baseUrl,
+        absoluteUrls: options.absoluteUrls,
         authMethods: options.authMethods,
       };
     } else {

--- a/src/model/cli.ts
+++ b/src/model/cli.ts
@@ -45,6 +45,7 @@ export interface CommandLineOptions {
   documentsSubdirectory: string;
   auth: OptAuthMethod[];
   baseUrl?: string;
+  absoluteUrls?: boolean;
   host?: string;
   port?: string;
   githubApiUrl?: string;

--- a/src/model/server.ts
+++ b/src/model/server.ts
@@ -7,6 +7,7 @@ export interface ProviderServerOptions {
   ordDirectory: string;
   ordDocumentsSubDirectory: string;
   baseUrl?: string;
+  absoluteUrls?: boolean;
   host?: string;
   port?: number;
   sourceType: OptSourceType;
@@ -81,6 +82,7 @@ export function buildProviderServerOptions(options: CommandLineOptions): Provide
     ordDirectory: parseOrdDirectory(options.directory, options.sourceType),
     ordDocumentsSubDirectory: trimLeadingAndTrailingSlashes(options.documentsSubdirectory) || "", // Ensure it's never undefined
     baseUrl: updateBaseUrl(options.baseUrl),
+    absoluteUrls: options.absoluteUrls === true,
     host: trimTrailingSlash(options.host),
     port: options.port ? parseInt(options.port) : undefined,
     sourceType: options.sourceType,

--- a/src/server.ts
+++ b/src/server.ts
@@ -303,6 +303,7 @@ async function setupRouting(server: FastifyInstanceType, opts: ProviderServerOpt
   const { router, cacheService } = await RouterFactory.createRouter({
     sourceType: opts.sourceType,
     baseUrl: baseUrl,
+    absoluteUrls: opts.absoluteUrls,
     authMethods: opts.authentication.methods,
     fqnDocumentMap: {},
     documentsSubDirectory: opts.ordDocumentsSubDirectory,

--- a/src/services/cacheService.ts
+++ b/src/services/cacheService.ts
@@ -300,7 +300,10 @@ export class CacheService implements CacheServiceInterface {
             processedDocsForFqn.push(processedDoc);
 
             // Add to ORD config
-            const documentUrl = joinUrlPaths(PATH_CONSTANTS.SERVER_PREFIX, relativePath.replace(/\.json$/, ""));
+            const rootRelative = joinUrlPaths(PATH_CONSTANTS.SERVER_PREFIX, relativePath.replace(/\.json$/, ""));
+            const documentUrl = this.processingContext!.absoluteUrls
+              ? this.processingContext!.baseUrl + rootRelative
+              : rootRelative;
             const perspective = getDocumentPerspective(jsonData as OrdDocument);
 
             const documentEntry: OrdV1DocumentDescription = {
@@ -358,15 +361,20 @@ export class CacheService implements CacheServiceInterface {
   }
 
   private processDocument(document: OrdDocument, directoryHash: string): OrdDocument {
+    const { baseUrl, absoluteUrls, authMethods } = this.processingContext!;
     const eventResources = processResourceDefinitions(
       document.eventResources || [],
-      this.processingContext?.authMethods || [],
+      authMethods || [],
+      baseUrl,
+      absoluteUrls,
     );
     const apiResources = processResourceDefinitions(
       document.apiResources || [],
-      this.processingContext?.authMethods || [],
+      authMethods || [],
+      baseUrl,
+      absoluteUrls,
     );
-    const packages = processPackageLinks(document.packages || []);
+    const packages = processPackageLinks(document.packages || [], baseUrl, absoluteUrls);
 
     const perspective = getDocumentPerspective(document);
 

--- a/src/services/cacheService.ts
+++ b/src/services/cacheService.ts
@@ -386,6 +386,9 @@ export class CacheService implements CacheServiceInterface {
     return {
       ...document,
       perspective,
+      // TODO: Once ORD spec v1.15 ships (https://github.com/open-resource-discovery/specification/pull/125),
+      // migrate provider baseUrl injection to the new document-level `baseUrl` field.
+      // See the note in documentService.ts processDocument() for the full explanation.
       describedSystemInstance: {
         ...document.describedSystemInstance,
         baseUrl: this.processingContext?.baseUrl,

--- a/src/services/documentService.ts
+++ b/src/services/documentService.ts
@@ -260,6 +260,12 @@ export class DocumentService implements DocumentServiceInterface {
     return {
       ...document,
       perspective,
+      // TODO: Once ORD spec v1.15 ships (https://github.com/open-resource-discovery/specification/pull/125),
+      // the provider server's baseUrl should be injected into the new document-level `baseUrl` field instead.
+      // `describedSystemInstance.baseUrl` is semantically the described system's URL (used for entry points),
+      // not the provider's URL (used for resolving metadata file references). Currently we inject the provider
+      // URL here as a v1.14 backward-compat fallback; after the spec package is updated to v1.15 this should
+      // be migrated to `OrdDocument.baseUrl` and `describedSystemInstance.baseUrl` should be left to the user.
       describedSystemInstance: {
         ...document.describedSystemInstance,
         baseUrl: this.processingContext.baseUrl,

--- a/src/services/documentService.ts
+++ b/src/services/documentService.ts
@@ -88,7 +88,7 @@ export class DocumentService implements DocumentServiceInterface {
             documentPaths.push(relativePath);
             processedDocsForFqn.push(processedDoc);
 
-            const documentUrl = joinUrlPaths(PATH_CONSTANTS.SERVER_PREFIX, relativePath.replace(/\.json$/, ""));
+            const documentUrl = this.buildDocumentUrl(relativePath);
             const perspective = getDocumentPerspective(document);
 
             const documentEntry: OrdV1DocumentDescription = {
@@ -234,13 +234,21 @@ export class DocumentService implements DocumentServiceInterface {
     return map;
   }
 
+  private buildDocumentUrl(relativePath: string): string {
+    const rootRelative = joinUrlPaths(PATH_CONSTANTS.SERVER_PREFIX, relativePath.replace(/\.json$/, ""));
+    return this.processingContext.absoluteUrls ? this.processingContext.baseUrl + rootRelative : rootRelative;
+  }
+
   private processDocument(document: OrdDocument, directoryHash: string | null): OrdDocument {
+    const { baseUrl, absoluteUrls, authMethods } = this.processingContext;
     const eventResources = processResourceDefinitions(
       document.eventResources || [],
-      this.processingContext.authMethods,
+      authMethods,
+      baseUrl,
+      absoluteUrls,
     );
-    const apiResources = processResourceDefinitions(document.apiResources || [], this.processingContext.authMethods);
-    const packages = processPackageLinks(document.packages || []);
+    const apiResources = processResourceDefinitions(document.apiResources || [], authMethods, baseUrl, absoluteUrls);
+    const packages = processPackageLinks(document.packages || [], baseUrl, absoluteUrls);
 
     const perspective = getDocumentPerspective(document);
 

--- a/src/services/interfaces/processingContext.ts
+++ b/src/services/interfaces/processingContext.ts
@@ -2,6 +2,7 @@ import { OptAuthMethod } from "../../model/cli.js";
 
 export interface ProcessingContext {
   baseUrl: string;
+  absoluteUrls?: boolean;
   authMethods: OptAuthMethod[];
   documentsSubDirectory?: string;
   githubBranch?: string;

--- a/src/util/__tests__/documentProcessing.test.ts
+++ b/src/util/__tests__/documentProcessing.test.ts
@@ -1,0 +1,116 @@
+import { fixResourceDefinitionUrl, processPackageLinks, processResourceDefinitions } from "../documentProcessing.js";
+import { OptAuthMethod } from "../../model/cli.js";
+
+jest.mock("../ordConfig.js", () => ({
+  getOrdDocumentAccessStrategies: (): { type: string }[] => [{ type: "open" }],
+}));
+
+const BASE_URL = "https://example.com";
+const ORD_ID = "sap.test:apiResource:myApi:v1";
+
+describe("fixResourceDefinitionUrl", () => {
+  describe("root-relative mode (absoluteUrls = false)", () => {
+    it("returns root-relative path for a relative URL", () => {
+      expect(fixResourceDefinitionUrl("./openapi.json", ORD_ID)).toBe("/ord/v1/openapi.json");
+    });
+
+    it("returns root-relative path with ORD ID segment restored", () => {
+      const escaped = "sap.test_apiResource_myApi_v1";
+      const url = `./${escaped}/openapi.json`;
+      expect(fixResourceDefinitionUrl(url, ORD_ID)).toBe(`/ord/v1/${ORD_ID}/openapi.json`);
+    });
+
+    it("leaves remote URLs untouched", () => {
+      const remote = "https://cdn.example.com/openapi.json";
+      expect(fixResourceDefinitionUrl(remote, ORD_ID)).toBe(remote);
+    });
+  });
+
+  describe("absolute URL mode (absoluteUrls = true)", () => {
+    it("prepends baseUrl to root-relative path", () => {
+      expect(fixResourceDefinitionUrl("./openapi.json", ORD_ID, BASE_URL, true)).toBe(
+        `${BASE_URL}/ord/v1/openapi.json`,
+      );
+    });
+
+    it("prepends baseUrl and restores ORD ID segment", () => {
+      const escaped = "sap.test_apiResource_myApi_v1";
+      const url = `./${escaped}/openapi.json`;
+      expect(fixResourceDefinitionUrl(url, ORD_ID, BASE_URL, true)).toBe(`${BASE_URL}/ord/v1/${ORD_ID}/openapi.json`);
+    });
+
+    it("leaves remote URLs untouched even in absolute mode", () => {
+      const remote = "https://cdn.example.com/openapi.json";
+      expect(fixResourceDefinitionUrl(remote, ORD_ID, BASE_URL, true)).toBe(remote);
+    });
+  });
+});
+
+describe("processPackageLinks", () => {
+  const pkg = {
+    ordId: "sap.test:package:myPkg:v1",
+    title: "My Package",
+    shortDescription: "short",
+    description: "desc",
+    version: "1.0.0",
+    partOfProducts: [],
+    vendor: "sap:vendor:SAP:",
+    packageLinks: [{ type: "license" as const, url: "licenses/license.txt" }],
+    files: [
+      {
+        fileFormat: "application/pdf" as const,
+        url: "docs/readme.pdf",
+        title: "Readme",
+        mediaType: "application/pdf" as const,
+      },
+    ],
+  };
+
+  it("converts relative packageLinks to root-relative by default", () => {
+    const result = processPackageLinks([pkg]);
+    expect(result[0].packageLinks![0].url).toBe("/ord/v1/licenses/license.txt");
+    expect(result[0].files![0].url).toBe("/ord/v1/docs/readme.pdf");
+  });
+
+  it("prepends baseUrl when absoluteUrls is true", () => {
+    const result = processPackageLinks([pkg], BASE_URL, true);
+    expect(result[0].packageLinks![0].url).toBe(`${BASE_URL}/ord/v1/licenses/license.txt`);
+    expect(result[0].files![0].url).toBe(`${BASE_URL}/ord/v1/docs/readme.pdf`);
+  });
+
+  it("leaves already-absolute URLs untouched", () => {
+    const pkgWithAbsolute = {
+      ...pkg,
+      packageLinks: [{ type: "license" as const, url: "https://example.com/license.txt" }],
+    };
+    const result = processPackageLinks([pkgWithAbsolute], BASE_URL, true);
+    expect(result[0].packageLinks![0].url).toBe("https://example.com/license.txt");
+  });
+});
+
+describe("processResourceDefinitions", () => {
+  const resource = {
+    ordId: ORD_ID,
+    title: "My API",
+    shortDescription: "short",
+    description: "desc",
+    version: "1.0.0",
+    releaseStatus: "active" as const,
+    visibility: "public" as const,
+    resourceDefinitions: [
+      { type: "openapi-v3" as const, mediaType: "application/json" as const, url: "./openapi.json" },
+    ],
+    partOfPackage: "sap.test:package:myPkg:v1",
+    apiProtocol: "rest" as const,
+  };
+
+  it("produces root-relative resource definition URLs by default", () => {
+    const result = processResourceDefinitions([resource], [OptAuthMethod.Open]);
+    expect(result[0].resourceDefinitions[0].url).toBe("/ord/v1/openapi.json");
+  });
+
+  it("produces absolute resource definition URLs when absoluteUrls is true", () => {
+    const result = processResourceDefinitions([resource], [OptAuthMethod.Open], BASE_URL, true);
+    expect(result[0].resourceDefinitions[0].url).toBe(`${BASE_URL}/ord/v1/openapi.json`);
+  });
+});

--- a/src/util/documentProcessing.ts
+++ b/src/util/documentProcessing.ts
@@ -5,7 +5,11 @@ import { PATH_CONSTANTS } from "../constant.js";
 import { getOrdDocumentAccessStrategies } from "./ordConfig.js";
 import { OptAuthMethod } from "../model/cli.js";
 
-export function fixResourceDefinitionUrl(url: string, ordId: string): string {
+function makeUrlPrefix(baseUrl: string, absoluteUrls: boolean): string {
+  return absoluteUrls ? baseUrl + PATH_CONSTANTS.SERVER_PREFIX : PATH_CONSTANTS.SERVER_PREFIX;
+}
+
+export function fixResourceDefinitionUrl(url: string, ordId: string, baseUrl = "", absoluteUrls = false): string {
   const escapedOrdId = ordIdToPathSegment(ordId);
   const pathParts = url.split("/");
   const ordIdIdx = pathParts.findIndex((part) => escapedOrdId === part);
@@ -19,13 +23,16 @@ export function fixResourceDefinitionUrl(url: string, ordId: string): string {
   if (isRemoteUrl(url)) {
     return urlWithFixedOrdId;
   }
+  const prefix = makeUrlPrefix(baseUrl, absoluteUrls);
   // Construct server-relative URL
-  return joinUrlPaths(PATH_CONSTANTS.SERVER_PREFIX, path.posix.resolve("/", urlWithFixedOrdId));
+  return prefix + joinUrlPaths(path.posix.resolve("/", urlWithFixedOrdId));
 }
 
 export function processResourceDefinitions<T extends EventResource | ApiResource>(
   resources: T[],
   authMethods: OptAuthMethod[],
+  baseUrl = "",
+  absoluteUrls = false,
 ): T[] {
   const accessStrategies = getOrdDocumentAccessStrategies(authMethods);
 
@@ -34,7 +41,7 @@ export function processResourceDefinitions<T extends EventResource | ApiResource
     resourceDefinitions: (resource.resourceDefinitions || []).map((definition) => {
       return {
         ...definition,
-        ...(definition.url && { url: fixResourceDefinitionUrl(definition.url, resource.ordId) }),
+        ...(definition.url && { url: fixResourceDefinitionUrl(definition.url, resource.ordId, baseUrl, absoluteUrls) }),
         accessStrategies,
       };
     }),
@@ -45,7 +52,8 @@ function isRelativeUrl(url: string): boolean {
   return !isRemoteUrl(url) && !url.startsWith("/");
 }
 
-export function processPackageLinks(packages: Package[]): Package[] {
+export function processPackageLinks(packages: Package[], baseUrl = "", absoluteUrls = false): Package[] {
+  const prefix = makeUrlPrefix(baseUrl, absoluteUrls);
   return packages.map((pkg) => ({
     ...pkg,
     ...(pkg.packageLinks && {
@@ -53,7 +61,7 @@ export function processPackageLinks(packages: Package[]): Package[] {
         ...link,
         ...(link.url &&
           isRelativeUrl(link.url) && {
-            url: joinUrlPaths(PATH_CONSTANTS.SERVER_PREFIX, path.posix.resolve("/", link.url)),
+            url: prefix + joinUrlPaths(path.posix.resolve("/", link.url)),
           }),
       })),
     }),
@@ -62,7 +70,7 @@ export function processPackageLinks(packages: Package[]): Package[] {
         ...file,
         ...(file.url &&
           isRelativeUrl(file.url) && {
-            url: joinUrlPaths(PATH_CONSTANTS.SERVER_PREFIX, path.posix.resolve("/", file.url)),
+            url: prefix + joinUrlPaths(path.posix.resolve("/", file.url)),
           }),
       })),
     }),


### PR DESCRIPTION
By default the server emits root-relative URLs (e.g. `/ord/v1/documents/my-doc`).                 
  When `--absolute-urls` (env: `ORD_ABSOLUTE_URLS=true`) is set, every URL in ORD
  responses is prefixed with `--base-url`, producing fully-qualified absolute URLs.                 
  Remote URLs already present in source documents are never modified.                               
                                                                                                    
  **Affected URL types:** document URLs in the ORD Configuration, resource definition               
  URLs, and package link/file URLs.                                                                 
                                                                                                    
  **Note:** The current injection of the provider `baseUrl` into                                    
  `describedSystemInstance.baseUrl` is a v1.14 backward-compat workaround.                          
  Per [ORD spec PR #125](https://github.com/open-resource-discovery/specification/pull/125),        
  ORD v1.15 will introduce a dedicated document-level `baseUrl` for the provider,                   
  making the distinction between provider URL (metadata files) and described system                 
  URL (entry points) explicit. A follow-up migration will be needed once the spec                   
  package is updated.

Relates
- https://github.com/open-resource-discovery/specification/pull/125