### PR TITLE
feat: add Cache-Control: no-cache header to all responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+## [[1.2.0](https://github.com/open-resource-discovery/provider-server/releases/tag/v1.2.0)] - 2026-06-10
+
+### Changed
+
+- Added `Cache-Control: no-cache` header to all responses, following the ORD spec recommendation to ensure caches always revalidate with the origin server rather than serving stale metadata.
+
 ## [[1.1.4](https://github.com/open-resource-discovery/provider-server/releases/tag/v1.1.4)] - 2026-05-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=24.10.7",

--- a/src/__tests__/server.integration.test.ts
+++ b/src/__tests__/server.integration.test.ts
@@ -374,7 +374,7 @@ describe("Server Integration", () => {
       });
     });
 
-    it("should return ETag headers for caching", async () => {
+    it("should return ETag and Cache-Control headers for caching", async () => {
       const credentials = Buffer.from("admin:secret").toString("base64");
       const response = await fetch(`${SERVER_URL}${PATH_CONSTANTS.DOCUMENTS_URL_PATH}/ref-app-example-1`, {
         headers: {
@@ -383,6 +383,7 @@ describe("Server Integration", () => {
       });
 
       expect(response.headers.get("etag")).toBeTruthy();
+      expect(response.headers.get("cache-control")).toBe("no-cache");
     });
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -267,6 +267,7 @@ async function setupServer(server: FastifyInstanceType, opts: ProviderServerOpti
     if (currentCommitHash) {
       reply.header("x-github-current-commit-hash", currentCommitHash);
     }
+    reply.header("cache-control", "no-cache");
     done();
   });
 }


### PR DESCRIPTION
Implements the ORD spec recommendation to provide a Cache-Control header on all GET endpoints, ensuring caches revalidate with the origin before serving a cached response rather than relying on heuristic caching.

Related:
- https://github.com/open-resource-discovery/specification/pull/150