### PR TITLE
fix: semver in document-file ending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Fixed
+
+- Serve ORD documents whose filename ends in a version segment (e.g. `..._1.0.0`); the version tail is no longer mistaken for a file extension.
+
 ## [[1.2.3](https://github.com/open-resource-discovery/provider-server/releases/tag/v1.2.3)] - 2026-06-23
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.2.4-dev.0",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/provider-server",
-      "version": "1.2.4-dev.0",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/auth": "5.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.2.3",
+  "version": "1.2.4-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/provider-server",
-      "version": "1.2.3",
+      "version": "1.2.4-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/auth": "5.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.2.3",
+  "version": "1.2.4-dev.0",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=24.10.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-resource-discovery/provider-server",
-  "version": "1.2.4-dev.0",
+  "version": "1.2.4",
   "description": "A CLI application or server that takes multiple ORD documents and other metadata files and exposes them as a ORD Provider implementation (ORD Document API)",
   "engines": {
     "node": ">=24.10.7",

--- a/src/routes/__tests__/documentRouter.test.ts
+++ b/src/routes/__tests__/documentRouter.test.ts
@@ -160,6 +160,27 @@ describe("DocumentRouter", () => {
       await expect(handler(mockRequest as FastifyRequest, mockReply)).rejects.toThrow(InternalServerError);
       expect(log.error).toHaveBeenCalled();
     });
+    it("should serve non-JSON files via getFileContent instead of getProcessedDocument", async () => {
+      const pdfContent = Buffer.from("PDF content");
+      mockDocumentService.getFileContent.mockResolvedValue(pdfContent);
+      mockRequest.params = { "*": "Files/DeveloperPortal/guide.pdf" };
+
+      await handler(mockRequest as FastifyRequest, mockReply);
+
+      expect(mockDocumentService.getFileContent).toHaveBeenCalledWith("documents/Files/DeveloperPortal/guide.pdf");
+      expect(mockDocumentService.getProcessedDocument).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith(pdfContent);
+    });
+
+    it("should serve .yaml files via getFileContent", async () => {
+      mockDocumentService.getFileContent.mockResolvedValue(Buffer.from("openapi: 3.0.0"));
+      mockRequest.params = { "*": "specs/api.yaml" };
+
+      await handler(mockRequest as FastifyRequest, mockReply);
+
+      expect(mockDocumentService.getFileContent).toHaveBeenCalledWith("documents/specs/api.yaml");
+      expect(mockDocumentService.getProcessedDocument).not.toHaveBeenCalled();
+    });
 
     it("should serve non-JSON files via getFileContent instead of getProcessedDocument", async () => {
       const pdfContent = Buffer.from("PDF content");
@@ -197,6 +218,33 @@ describe("DocumentRouter", () => {
       expect(mockDocumentService.getFileContent).toHaveBeenCalledWith("documents/Artifacts/api/api.json");
       expect(mockReply.type).toHaveBeenCalledWith("application/json");
       expect(mockReply.send).toHaveBeenCalledWith(swaggerDef);
+    });
+
+    it("should treat a semver-tailed document name as an ORD document, not a file", async () => {
+      const mockDoc = { openResourceDiscovery: "1.9" };
+      mockDocumentService.getProcessedDocument.mockResolvedValue(mockDoc as never);
+      mockRequest.params = { "*": "sap.bdc.ccm_package_DataProducts_1.0.0" };
+
+      await handler(mockRequest as FastifyRequest, mockReply);
+
+      expect(mockDocumentService.getProcessedDocument).toHaveBeenCalledWith(
+        "documents/sap.bdc.ccm_package_DataProducts_1.0.0.json",
+      );
+      expect(mockDocumentService.getFileContent).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith(mockDoc);
+    });
+
+    it("should serve a semver-tailed document even when requested with the .json extension", async () => {
+      const mockDoc = { openResourceDiscovery: "1.9" };
+      mockDocumentService.getProcessedDocument.mockResolvedValue(mockDoc as never);
+      mockRequest.params = { "*": "sap.bdc.ccm_package_DataProducts_1.0.0.json" };
+
+      await handler(mockRequest as FastifyRequest, mockReply);
+
+      expect(mockDocumentService.getProcessedDocument).toHaveBeenCalledWith(
+        "documents/sap.bdc.ccm_package_DataProducts_1.0.0.json",
+      );
+      expect(mockDocumentService.getFileContent).not.toHaveBeenCalled();
     });
   });
 

--- a/src/routes/documentRouter.ts
+++ b/src/routes/documentRouter.ts
@@ -42,10 +42,12 @@ export class DocumentRouter extends BaseRouter {
       const { "*": documentPath } = request.params as { "*": string };
       const relativePath = `${this.documentsSubDirectory}/${documentPath}`;
 
-      // If the path has a non-JSON file extension, serve as raw file content.
-      // Use a strict regex to avoid matching ORD-style names with dots (e.g., "sap.ref-app-example").
+      // A path with a non-`.json` file extension is a raw resource file (linked from a package,
+      // e.g. OpenAPI YAML, PDF) and is served verbatim. An extension is a trailing dot-segment
+      // starting with a letter, so numeric semver tails on ORD document names (e.g. "..._1.0.0")
+      // are NOT treated as extensions and fall through to ORD-document serving below.
       const fileName = documentPath.split("/").pop() || "";
-      const hasFileExtension = /\.[a-zA-Z0-9]{1,10}$/.test(fileName);
+      const hasFileExtension = /\.[a-zA-Z][a-zA-Z0-9]*$/.test(fileName);
       if (hasFileExtension && !documentPath.endsWith(".json")) {
         log.info(`[FILES ROUTE] Request received for file: ${relativePath}`);
         try {
@@ -61,6 +63,7 @@ export class DocumentRouter extends BaseRouter {
         }
       }
 
+      // ORD documents are always `.json`; append the extension if the request omitted it.
       const documentPathWithExtension = documentPath.endsWith(".json") ? documentPath : `${documentPath}.json`;
       const documentRelativePath = `${this.documentsSubDirectory}/${documentPathWithExtension}`;
       log.info(`[DOCUMENTS ROUTE] Request received for ORD document: ${documentRelativePath}`);
@@ -69,12 +72,12 @@ export class DocumentRouter extends BaseRouter {
         const document = await this.documentService.getProcessedDocument(documentRelativePath);
         return reply.send(document);
       } catch (error) {
-        // If NotFoundError for a .json path, the file might be a resource file (e.g. Swagger/OpenAPI)
-        // rather than an ORD document. Fall back to serving it as raw file content.
-        if (error instanceof NotFoundError && documentPath.endsWith(".json")) {
-          log.info(`[DOCUMENTS ROUTE] Not an ORD document, falling back to file serving: ${relativePath}`);
+        // The path might be a non-ORD resource file (e.g. Swagger/OpenAPI JSON) rather than an
+        // ORD document. Fall back to serving it as raw file content.
+        if (error instanceof NotFoundError) {
+          log.info(`[DOCUMENTS ROUTE] Not an ORD document, falling back to file serving: ${documentRelativePath}`);
           try {
-            const content = await this.documentService.getFileContent(relativePath);
+            const content = await this.documentService.getFileContent(documentRelativePath);
             const contentString = Buffer.isBuffer(content) ? content.toString("utf-8") : content;
             try {
               const jsonData = JSON.parse(contentString);


### PR DESCRIPTION
Serve ORD documents whose filename ends in a version segment